### PR TITLE
Remove `transformOptions`

### DIFF
--- a/lib/nel.js
+++ b/lib/nel.js
@@ -50,11 +50,8 @@ var path = require("path");
 var spawn = require("child_process").spawn;
 
 var transform = require("babel-core").transform;
-var transformOptions = {
-    presets: ["es2015"],
-};
 var transpile = function (code) {
-    return transform(code, transformOptions).code;
+    return transform(code).code;
 };
 
 var doc = require("./mdn.js"); // Documentation for Javascript builtins


### PR DESCRIPTION
Partially fixes https://github.com/n-riesco/jp-babel/issues/2

Theoretically, if options are not passed to `babel.transform` then babel should use the `.babelrc` options. I haven't fully tested to determine if this in fact is happening. I know that module `import` is not working in the notebook within a project that has a qualified `.babelrc`...
